### PR TITLE
Add 915005997001 (Enrave XL with Bluetooth)

### DIFF
--- a/devices/philips.js
+++ b/devices/philips.js
@@ -109,6 +109,15 @@ module.exports = [
         ota: ota.zigbeeOTA,
     },
     {
+        zigbeeModel: ['915005997001', '915005997101'],
+        model: '915005997001',
+        vendor: 'Philips',
+        description: 'Hue white ambiance ceiling light Enrave XL with Bluetooth',
+        meta: {turnsOffAtBrightness1: true},
+        extend: hueExtend.light_onoff_brightness_colortemp({colorTempRange: [153, 454]}),
+        ota: ota.zigbeeOTA,
+    },
+    {
         zigbeeModel: ['929003054001'],
         model: '929003054001',
         vendor: 'Philips',


### PR DESCRIPTION
Add support for [915005997001](https://www.philips-hue.com/en-gb/p/hue-white-ambiance-enrave-extra-large-ceiling-lamp/4116131P6).
I also included the variant with the black housing ([915005997101](https://www.philips-hue.com/en-gb/p/hue-white-ambiance-enrave-extra-large-ceiling-lamp/4116130P6)), although I don't have that lamp and could not test it.